### PR TITLE
fix: apply Next.js revalidate option exclusively in development environment

### DIFF
--- a/app/[lang]/[[...slug]]/page.tsx
+++ b/app/[lang]/[[...slug]]/page.tsx
@@ -50,7 +50,6 @@ const getData = async (
     slug: cleanSlug,
     language: locale,
     config,
-    fetchOptions: { next: { revalidate: 3 } },
   }).catch(() => {
     errorPage = true
     return null
@@ -62,6 +61,8 @@ const getData = async (
     errorPage,
   }
 }
+
+export const revalidate = process.env.NODE_ENV === 'development' ? 3 : false
 
 export async function generateStaticParams({
   params,

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -29,16 +29,13 @@ const getData = async (
   }
 
   const [tags, posts] = await Promise.all([
-    fetchTags(config.apiKey, undefined, undefined, undefined, {
-      next: { revalidate: 3 },
-    }),
+    fetchTags(config.apiKey),
     fetchPages({
       type: 'blog',
       pageSize: 1000,
       sort: '-publishedAt',
       fetchExternalData: true,
       config,
-      fetchOptions: { next: { revalidate: 3 } },
     }).catch(() => {
       errorPage = true
       return null
@@ -52,6 +49,8 @@ const getData = async (
     errorPage,
   }
 }
+
+export const revalidate = process.env.NODE_ENV === 'development' ? 3 : false
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -74,9 +73,7 @@ export default async function Page({ params }: { params: { lang: string } }) {
               </h1>
 
               <div className="flex flex-wrap items-center">
-                {tags?.map((tag) => (
-                  <TagListItem tag={tag} key={tag} />
-                ))}
+                {tags?.map((tag) => <TagListItem tag={tag} key={tag} />)}
               </div>
 
               <hr className="mt-6 mb-10 dark:border-gray-600" />

--- a/app/[lang]/blog/post/[[...slug]]/page.tsx
+++ b/app/[lang]/blog/post/[[...slug]]/page.tsx
@@ -50,7 +50,6 @@ const getData = async (
     slug: cleanSlug,
     language: locale,
     config,
-    fetchOptions: { next: { revalidate: 3 } },
   }).catch(() => {
     errorPage = true
     return null
@@ -62,6 +61,8 @@ const getData = async (
     errorPage,
   }
 }
+
+export const revalidate = process.env.NODE_ENV === 'development' ? 3 : false
 
 export async function generateStaticParams({
   params,

--- a/app/[lang]/blog/tag/[tag]/page.tsx
+++ b/app/[lang]/blog/tag/[tag]/page.tsx
@@ -37,14 +37,11 @@ const getData = async (
       pageSize: 1000,
       sort: '-publishedAt',
       config,
-      fetchOptions: { next: { revalidate: 3 } },
     }).catch(() => {
       errorPage = true
       return null
     }),
-    fetchTags(config.apiKey, undefined, undefined, undefined, {
-      next: { revalidate: 3 },
-    }),
+    fetchTags(config.apiKey),
   ])
 
   return {
@@ -54,6 +51,8 @@ const getData = async (
     errorPage,
   }
 }
+
+export const revalidate = process.env.NODE_ENV === 'development' ? 3 : false
 
 export async function generateStaticParams({
   params,
@@ -114,9 +113,7 @@ export default async function Page({
               </div>
 
               <div className="flex flex-wrap items-center">
-                {tags?.map((tag) => (
-                  <TagListItem tag={tag} key={tag} />
-                ))}
+                {tags?.map((tag) => <TagListItem tag={tag} key={tag} />)}
               </div>
 
               <hr className="mt-6 mb-10 dark:border-gray-600" />


### PR DESCRIPTION
I have removed all instances of the revalidate option from the fetch functions and reintroduced it exclusively for the development environment using Next.js’s revalidate configuration.
This change ensures that the revalidate behavior is scoped appropriately to development, optimizing performance and preventing unnecessary revalidation in production.